### PR TITLE
Add a Dropdown element

### DIFF
--- a/crates/oku_core/src/components/update_result.rs
+++ b/crates/oku_core/src/components/update_result.rs
@@ -78,4 +78,9 @@ impl UpdateResult {
         self.propagate = false;
         self
     }
+
+    pub(crate) fn result_message(mut self, message: OkuMessage) -> Self {
+        self.result_message = Some(message);
+        self
+    }
 }

--- a/crates/oku_core/src/devtools/dev_tools_element.rs
+++ b/crates/oku_core/src/devtools/dev_tools_element.rs
@@ -118,6 +118,7 @@ impl Element for DevTools {
         element_state: &mut ElementStateStore,
         scale_factor: f64,
     ) -> Option<NodeId> {
+        self.merge_default_style();
         let mut child_nodes: Vec<NodeId> = Vec::with_capacity(self.children().len());
 
         for child in self.common_element_data.children.iter_mut() {

--- a/crates/oku_core/src/elements/canvas.rs
+++ b/crates/oku_core/src/elements/canvas.rs
@@ -136,6 +136,7 @@ impl Element for Canvas {
         element_state: &mut ElementStateStore,
         scale_factor: f64,
     ) -> Option<NodeId> {
+        self.merge_default_style();
         let mut child_nodes: Vec<NodeId> = Vec::with_capacity(self.children().len());
 
         for child in self.common_element_data.children.iter_mut() {

--- a/crates/oku_core/src/elements/container.rs
+++ b/crates/oku_core/src/elements/container.rs
@@ -79,6 +79,7 @@ impl Element for Container {
         element_state: &mut ElementStateStore,
         scale_factor: f64,
     ) -> Option<NodeId> {
+        self.merge_default_style();
         let mut child_nodes: Vec<NodeId> = Vec::with_capacity(self.children().len());
 
         for child in self.common_element_data.children.iter_mut() {

--- a/crates/oku_core/src/elements/dropdown.rs
+++ b/crates/oku_core/src/elements/dropdown.rs
@@ -218,7 +218,8 @@ impl Element for Dropdown {
                         if child.1.in_bounds(pointer_button.position) {
                             state.selected_item = Some(child.0);
                             state.is_open = false;
-                            break;
+
+                            return UpdateResult::default().result_message(OkuMessage::DropdownItemSelected(state.selected_item.unwrap()))
                         }
                     }
 
@@ -227,6 +228,7 @@ impl Element for Dropdown {
                     let dropdown_selection_in_bounds = transformed_border_rectangle.contains(&pointer_button.position);
                     if dropdown_selection_in_bounds {
                         state.is_open = !state.is_open;
+                        return UpdateResult::default().result_message(OkuMessage::DropdownToggled(state.is_open));
                     }
 
                 }
@@ -237,7 +239,9 @@ impl Element for Dropdown {
             OkuMessage::PointerMovedEvent(_) => {}
             OkuMessage::MouseWheelEvent(_) => {}
             OkuMessage::ImeEvent(_) => {}
-            OkuMessage::TextInputChanged(_) => {}
+            OkuMessage::TextInputChanged(_) => {},
+            OkuMessage::DropdownToggled(_) => {},
+            OkuMessage::DropdownItemSelected(_) => {}
         }
 
         UpdateResult::default()

--- a/crates/oku_core/src/elements/dropdown.rs
+++ b/crates/oku_core/src/elements/dropdown.rs
@@ -13,7 +13,7 @@ use crate::{generate_component_methods, RendererBox};
 use parley::FontContext;
 use std::any::Any;
 use peniko::Color;
-use taffy::{NodeId, Overflow, Position, TaffyTree, TraversePartialTree};
+use taffy::{NodeId, Position, TaffyTree, TraversePartialTree};
 use crate::elements::Container;
 
 /// The index of the dropdown list in the layout tree.

--- a/crates/oku_core/src/elements/dropdown.rs
+++ b/crates/oku_core/src/elements/dropdown.rs
@@ -1,0 +1,278 @@
+use crate::components::component::{ComponentOrElement, ComponentSpecification};
+use crate::components::Props;
+use crate::components::UpdateResult;
+use crate::elements::common_element_data::CommonElementData;
+use crate::elements::element::{Element, ElementBox};
+use crate::elements::element_styles::ElementStyles;
+use crate::elements::layout_context::LayoutContext;
+use crate::events::OkuMessage;
+use crate::geometry::{Point, Size};
+use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
+use crate::style::{Display, FlexDirection, Style};
+use crate::{generate_component_methods_no_children, RendererBox};
+use parley::FontContext;
+use std::any::Any;
+use taffy::{NodeId, Position, TaffyTree};
+use crate::elements::{Container, Text};
+
+/// An element for storing related elements.
+#[derive(Clone, Default, Debug)]
+pub struct Dropdown {
+    pub common_element_data: CommonElementData,
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct DropdownState {
+    is_open: bool,
+    selected_item: Option<usize>,
+}
+
+impl Element for Dropdown {
+    fn common_element_data(&self) -> &CommonElementData {
+        &self.common_element_data
+    }
+
+    fn common_element_data_mut(&mut self) -> &mut CommonElementData {
+        &mut self.common_element_data
+    }
+
+    fn name(&self) -> &'static str {
+        "Dropdown"
+    }
+
+    fn draw(
+        &mut self,
+        renderer: &mut RendererBox,
+        font_context: &mut FontContext,
+        taffy_tree: &mut TaffyTree<LayoutContext>,
+        _root_node: NodeId,
+        element_state: &ElementStateStore,
+        pointer: Option<Point>,
+    ) {
+        // We draw the borders before we start any layers, so that we don't clip the borders.
+        self.draw_borders(renderer);
+        self.maybe_start_layer(renderer);
+        {
+            self.draw_children(renderer, font_context, taffy_tree, element_state, pointer);
+        }
+        self.maybe_end_layer(renderer);
+    }
+
+    fn compute_layout(
+        &mut self,
+        taffy_tree: &mut TaffyTree<LayoutContext>,
+        element_state: &mut ElementStateStore,
+        scale_factor: f64,
+    ) -> Option<NodeId> {
+        let mut child_nodes: Vec<NodeId> = Vec::with_capacity(self.children().len());
+
+        let state = self.get_base_state_mut(element_state).data.as_mut().downcast_mut::<DropdownState>().unwrap();
+
+        // Update the dropdown selection based off the current selection.
+        let mut selection: Option<ElementBox> = None;
+        if let Some(dropdown_list) = self.dropdown_list_mut() {
+            for child in dropdown_list.internal.children_mut().iter_mut().enumerate() {
+                if Some(child.0) == state.selected_item {
+                    selection = Some(child.1).cloned()
+                }
+            }
+        }
+
+        if let Some(dropdown_selection) = self.dropdown_selection_mut() {
+            if let Some(selection) = selection {
+                *dropdown_selection = selection;
+            }
+        }
+
+        if state.is_open {
+            for child in self.children_mut().iter_mut() {
+                let child_node = child.internal.compute_layout(taffy_tree, element_state, scale_factor);
+                if let Some(child_node) = child_node {
+                    child_nodes.push(child_node);
+                }
+            }
+        } else if let Some(dropdown_selection) = self.dropdown_selection_mut() {
+            let child_node = dropdown_selection.internal.compute_layout(taffy_tree, element_state, scale_factor);
+            if let Some(child_node) = child_node {
+                child_nodes.push(child_node);
+            }
+        }
+
+        let style: taffy::Style = self.common_element_data.style.to_taffy_style_with_scale_factor(scale_factor);
+
+        self.common_element_data_mut().taffy_node_id = Some(taffy_tree.new_with_children(style, &child_nodes).unwrap());
+        self.common_element_data().taffy_node_id
+    }
+
+    fn finalize_layout(
+        &mut self,
+        taffy_tree: &mut TaffyTree<LayoutContext>,
+        root_node: NodeId,
+        position: Point,
+        z_index: &mut u32,
+        transform: glam::Mat4,
+        element_state: &mut ElementStateStore,
+        pointer: Option<Point>,
+    ) {
+        let result = taffy_tree.layout(root_node).unwrap();
+        self.resolve_layer_rectangle(position, transform, result, z_index);
+
+        self.finalize_borders();
+
+        self.common_element_data.scrollbar_size = Size::new(result.scrollbar_size.width, result.scrollbar_size.height);
+        self.common_element_data.computed_scrollbar_size = Size::new(result.scroll_width(), result.scroll_height());
+
+        for child in self.common_element_data.children.iter_mut() {
+            let taffy_child_node_id = child.internal.common_element_data().taffy_node_id;
+            if taffy_child_node_id.is_none() {
+                continue;
+            }
+
+            child.internal.finalize_layout(
+                taffy_tree,
+                taffy_child_node_id.unwrap(),
+                self.common_element_data.computed_layered_rectangle.position,
+                z_index,
+                transform,
+                element_state,
+                pointer,
+            );
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn in_bounds(&self, point: Point) -> bool {
+
+        // Check the bounds of the dropdown selection.
+        let common_element_data = self.common_element_data();
+        let transformed_border_rectangle = common_element_data.computed_layered_rectangle_transformed.border_rectangle();
+        let dropdown_selection_in_bounds = transformed_border_rectangle.contains(&point);
+
+        // Check the bounds of the dropdown list.
+        let dropdown_list_in_bounds = if let Some(dropdown_list) = self.dropdown_list() {
+            dropdown_list.in_bounds(point)
+        } else {
+            false
+        };
+
+        dropdown_selection_in_bounds || dropdown_list_in_bounds
+    }
+
+    fn on_event(&self, message: OkuMessage, element_state: &mut ElementStateStore) -> UpdateResult {
+        let base_state = self.get_base_state_mut(element_state);
+        let state = base_state.data.as_mut().downcast_mut::<DropdownState>().unwrap();
+
+        match message {
+            OkuMessage::PointerButtonEvent(pointer_button) => {
+
+                if message.clicked() {
+
+                    if let Some(dropdown_list) = self.dropdown_list() {
+                        for dropdown_list_item in dropdown_list.children().iter().enumerate() {
+                            if dropdown_list_item.1.in_bounds(pointer_button.position) {
+                                state.selected_item = Some(dropdown_list_item.0);
+                                state.is_open = !state.is_open;
+                            }
+                        }
+                    }
+
+                    if let Some(child) = self.dropdown_selection() {
+                        if child.in_bounds(pointer_button.position) {
+                            state.is_open = !state.is_open;
+                        }
+                    }
+
+                }
+
+            }
+            OkuMessage::Initialized => {}
+            OkuMessage::KeyboardInputEvent(_) => {}
+            OkuMessage::PointerMovedEvent(_) => {}
+            OkuMessage::MouseWheelEvent(_) => {}
+            OkuMessage::ImeEvent(_) => {}
+            OkuMessage::TextInputChanged(_) => {}
+        }
+
+        UpdateResult::default()
+    }
+
+    fn initialize_state(&self) -> ElementStateStoreItem {
+        ElementStateStoreItem {
+            base: Default::default(),
+            data: Box::new(DropdownState::default()),
+        }
+    }
+
+    fn children(&self) -> Vec<&dyn Element> {
+        self.common_element_data().children.iter().map(|x| x.internal.as_ref()).collect()
+    }
+}
+
+impl Dropdown {
+    #[allow(dead_code)]
+    fn get_state<'a>(&self, element_state: &'a ElementStateStore) -> &'a DropdownState {
+        element_state.storage.get(&self.common_element_data.component_id).unwrap().data.as_ref().downcast_ref().unwrap()
+    }
+
+    pub fn new() -> Dropdown {
+        Dropdown {
+            common_element_data: Default::default(),
+        }
+    }
+
+    // Note: Only use these functions in update, on_event, but not in user-land functions like .push().
+    pub(crate) fn dropdown_selection(&self) -> Option<&dyn Element> {
+        self.children().first().map(|v| &**v)
+    }
+
+    pub(crate) fn dropdown_list(&self) -> Option<&dyn Element> {
+        self.children().get(1).map(|v| &**v)
+    }
+
+    pub(crate) fn dropdown_selection_mut(&mut self) -> Option<&mut ElementBox> {
+        self.children_mut().first_mut()
+    }
+
+    pub(crate) fn dropdown_list_mut(&mut self) -> Option<&mut ElementBox> {
+        self.children_mut().get_mut(1)
+    }
+
+    generate_component_methods_no_children!();
+
+    #[allow(dead_code)]
+    pub fn push<T>(mut self, component_specification: T) -> Self
+    where
+        T: Into<ComponentSpecification> + Clone,
+    {
+
+        if self.common_element_data.child_specs.is_empty() {
+            // Create the selection when pushing to the 1st element.
+            self.common_element_data.child_specs.push(Container::new().push(component_specification.clone()).into());
+
+            // Create the dropdown list with their 1st child.
+            self.common_element_data.child_specs.push(
+                Container::new()
+                    .display(Display::Flex)
+                    .flex_direction(FlexDirection::Column)
+                    .position(Position::Absolute)
+                    .inset("100%", "0%", "0%", "0%")
+                    .push(component_specification.clone())
+                    .into()
+            );
+        } else if let Some(dropdown_list) = self.common_element_data.child_specs.get_mut(1) {
+            // Append to the dropdown list.
+            dropdown_list.children.push(component_specification.into());
+        }
+
+        self
+    }
+}
+
+impl ElementStyles for Dropdown {
+    fn styles_mut(&mut self) -> &mut Style {
+        self.common_element_data.current_style_mut()
+    }
+}

--- a/crates/oku_core/src/elements/element.rs
+++ b/crates/oku_core/src/elements/element.rs
@@ -13,7 +13,7 @@ use crate::RendererBox;
 use parley::FontContext;
 use std::any::Any;
 use std::fmt::Debug;
-use taffy::{NodeId, Overflow, TaffyTree};
+use taffy::{NodeId, Overflow, Position, TaffyTree};
 
 #[derive(Clone, Debug)]
 pub struct ElementBox {
@@ -125,9 +125,14 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
 
         let position = match common_element_data_mut.style.position() {
             taffy::Position::Relative => relative_position + result.location.into(),
-            taffy::Position::Absolute => result.location.into(),
+            taffy::Position::Absolute => relative_position + result.location.into(),
         };
 
+        let mut size = result.size.into();
+        if common_element_data_mut.style.position() == Position::Absolute {
+            size = Size::new(result.content_size.width, result.content_size.height);
+        }
+        
         common_element_data_mut.computed_border_rectangle_overflow_size =
             Size::new(result.content_size.width, result.content_size.height);
         common_element_data_mut.computed_layered_rectangle = ElementRectangle {
@@ -135,7 +140,7 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
             border: Border::new(result.border.top, result.border.right, result.border.bottom, result.border.left),
             padding: Padding::new(result.padding.top, result.padding.right, result.padding.bottom, result.padding.left),
             position,
-            size: result.size.into(),
+            size,
         };
         common_element_data_mut.computed_layered_rectangle_transformed =
             common_element_data_mut.computed_layered_rectangle.transform(scroll_transform);

--- a/crates/oku_core/src/elements/element.rs
+++ b/crates/oku_core/src/elements/element.rs
@@ -125,10 +125,19 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
 
         let position = match common_element_data_mut.style.position() {
             taffy::Position::Relative => relative_position + result.location.into(),
+            // We'll need to create our own enum for this because currently, relative acts more like static and absolute acts like relative.
             taffy::Position::Absolute => relative_position + result.location.into(),
         };
 
         let mut size = result.size.into();
+        // FIXME: Don't use the content size for position absolute containers.
+        // The following is a broken layout using result.size.
+        // └──  FLEX COL [x: 1    y: 44   w: 140  h: 45   content_w: 139  content_h: 142  border: l:1 r:1 t:1 b:1, padding: l:12 r:12 t:8 b:8] (NodeId(4294967303))
+        //     ├──  LEAF [x: 13   y: 9    w: 114  h: 25   content_w: 29   content_h: 25   border: l:0 r:0 t:0 b:0, padding: l:0 r:0 t:0 b:0] (NodeId(4294967298))
+        //     ├──  LEAF [x: 13   y: 34   w: 114  h: 25   content_w: 29   content_h: 25   border: l:0 r:0 t:0 b:0, padding: l:0 r:0 t:0 b:0] (NodeId(4294967299))
+        //     ├──  LEAF [x: 13   y: 59   w: 114  h: 25   content_w: 29   content_h: 25   border: l:0 r:0 t:0 b:0, padding: l:0 r:0 t:0 b:0] (NodeId(4294967300))
+        //     ├──  LEAF [x: 13   y: 84   w: 114  h: 25   content_w: 29   content_h: 25   border: l:0 r:0 t:0 b:0, padding: l:0 r:0 t:0 b:0] (NodeId(4294967301))
+        //     └──  LEAF [x: 13   y: 109  w: 114  h: 25   content_w: 29   content_h: 25   border: l:0 r:0 t:0 b:0, padding: l:0 r:0 t:0 b:0] (NodeId(4294967302))
         if common_element_data_mut.style.position() == Position::Absolute {
             size = Size::new(result.content_size.width, result.content_size.height);
         }
@@ -329,11 +338,11 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
 
     /// Called on sequential renders to update any state that the element may have.
     fn update_state(&self, _element_state: &mut ElementStateStore, _reload_fonts: bool) {}
-    
+
     fn default_style(&self) -> Style {
         Style::default()
     }
-    
+
     fn merge_default_style(&mut self) {
         self.common_element_data_mut().style = Style::merge(&self.default_style(), &self.common_element_data().style);
     }

--- a/crates/oku_core/src/elements/element.rs
+++ b/crates/oku_core/src/elements/element.rs
@@ -329,6 +329,14 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
 
     /// Called on sequential renders to update any state that the element may have.
     fn update_state(&self, _element_state: &mut ElementStateStore, _reload_fonts: bool) {}
+    
+    fn default_style(&self) -> Style {
+        Style::default()
+    }
+    
+    fn merge_default_style(&mut self) {
+        self.common_element_data_mut().style = Style::merge(&self.default_style(), &self.common_element_data().style);
+    }
 }
 
 impl<T: Element> From<T> for ElementBox {

--- a/crates/oku_core/src/elements/image.rs
+++ b/crates/oku_core/src/elements/image.rs
@@ -68,6 +68,7 @@ impl Element for Image {
         _element_state: &mut ElementStateStore,
         scale_factor: f64,
     ) -> Option<NodeId> {
+        self.merge_default_style();
         let style: taffy::Style = self.common_element_data.style.to_taffy_style_with_scale_factor(scale_factor);
 
         self.common_element_data_mut().taffy_node_id = Some(

--- a/crates/oku_core/src/elements/mod.rs
+++ b/crates/oku_core/src/elements/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod image;
 pub(crate) mod layout_context;
 pub(crate) mod span;
 pub(crate) mod text;
+pub(crate) mod dropdown;
 
 #[allow(clippy::module_inception)]
 pub(crate) mod text_input;
@@ -25,4 +26,5 @@ pub use crate::elements::font::Font;
 pub use crate::elements::image::Image;
 pub use crate::elements::span::Span;
 pub use crate::elements::text::Text;
+pub use crate::elements::dropdown::Dropdown;
 pub use crate::elements::text_input::text_input::TextInput;

--- a/crates/oku_core/src/elements/span.rs
+++ b/crates/oku_core/src/elements/span.rs
@@ -85,6 +85,7 @@ impl Element for Span {
         element_state: &mut ElementStateStore,
         scale_factor: f64,
     ) -> Option<NodeId> {
+        self.merge_default_style();
         let mut child_nodes: Vec<NodeId> = Vec::with_capacity(self.children().len());
 
         for child in self.common_element_data.children.iter_mut() {

--- a/crates/oku_core/src/elements/text/text.rs
+++ b/crates/oku_core/src/elements/text/text.rs
@@ -129,6 +129,7 @@ impl Element for Text {
         _element_state: &mut ElementStateStore,
         scale_factor: f64,
     ) -> Option<NodeId> {
+        self.merge_default_style();
         let style: taffy::Style = self.common_element_data.style.to_taffy_style_with_scale_factor(scale_factor);
 
         self.common_element_data_mut().taffy_node_id = Some(

--- a/crates/oku_core/src/elements/text_input/text_input.rs
+++ b/crates/oku_core/src/elements/text_input/text_input.rs
@@ -140,6 +140,7 @@ impl Element for TextInput {
         _element_state: &mut ElementStateStore,
         scale_factor: f64,
     ) -> Option<NodeId> {
+        self.merge_default_style();
         let style: taffy::Style = self.common_element_data.style.to_taffy_style_with_scale_factor(scale_factor);
 
         self.common_element_data_mut().taffy_node_id = Some(

--- a/crates/oku_core/src/events/mod.rs
+++ b/crates/oku_core/src/events/mod.rs
@@ -58,6 +58,8 @@ pub enum OkuMessage {
     MouseWheelEvent(MouseWheel),
     ImeEvent(Ime),
     TextInputChanged(String),
+    DropdownToggled(bool),
+    DropdownItemSelected(usize),
 }
 
 impl OkuMessage {

--- a/crates/oku_core/src/events/mod.rs
+++ b/crates/oku_core/src/events/mod.rs
@@ -58,7 +58,10 @@ pub enum OkuMessage {
     MouseWheelEvent(MouseWheel),
     ImeEvent(Ime),
     TextInputChanged(String),
+    /// Generated when a dropdown is opened or closed. The boolean is the status of is_open after the event has occurred.
     DropdownToggled(bool),
+    /// The index of the item selected in the list.
+    /// For example, if you select the first item the index will be 0.
     DropdownItemSelected(usize),
 }
 

--- a/crates/oku_core/src/style/styles.rs
+++ b/crates/oku_core/src/style/styles.rs
@@ -573,6 +573,7 @@ impl Style {
             || self.dirty_flags.contains(StyleFlags::BORDER_COLOR)
     }
 
+    /// Take an old style and update it with the non-default values from the new style.
     pub fn merge(old: &Self, new: &Self) -> Self {
         let old_dirty_flags = old.dirty_flags;
         let new_dirty_flags = new.dirty_flags;
@@ -580,11 +581,11 @@ impl Style {
         if old_dirty_flags.is_empty() {
             return *new;
         }
-        
+
         if new_dirty_flags.is_empty() {
             return *old;
         }
-        
+
         let font_family_length = if new_dirty_flags.contains(StyleFlags::FONT_FAMILY_LENGTH) {
             new.font_family_length
         } else {

--- a/crates/oku_core/src/style/styles.rs
+++ b/crates/oku_core/src/style/styles.rs
@@ -195,7 +195,7 @@ impl Default for Style {
             font_family_length: 0,
             font_family: [0; 64],
             box_sizing: BoxSizing::BorderBox,
-            scrollbar_width: if cfg!(any(target_os = "android", target_os = "ios")) { 0.0 } else { 15.0 },
+            scrollbar_width: if cfg!(any(target_os = "android", target_os = "ios")) { 0.0 } else { 10.0 },
             position: Position::Relative,
             margin: [Unit::Px(0.0); 4],
             padding: [Unit::Px(0.0); 4],
@@ -571,5 +571,269 @@ impl Style {
         self.dirty_flags.contains(StyleFlags::BORDER_WIDTH)
             || self.dirty_flags.contains(StyleFlags::BORDER_RADIUS)
             || self.dirty_flags.contains(StyleFlags::BORDER_COLOR)
+    }
+
+    pub fn merge(old: &Self, new: &Self) -> Self {
+        let old_dirty_flags = old.dirty_flags;
+        let new_dirty_flags = new.dirty_flags;
+
+        if old_dirty_flags.is_empty() {
+            return *new;
+        }
+        
+        if new_dirty_flags.is_empty() {
+            return *old;
+        }
+        
+        let font_family_length = if new_dirty_flags.contains(StyleFlags::FONT_FAMILY_LENGTH) {
+            new.font_family_length
+        } else {
+            old.font_family_length
+        };
+
+        let font_family = if new_dirty_flags.contains(StyleFlags::FONT_FAMILY) {
+            new.font_family
+        } else {
+            old.font_family
+        };
+
+        let box_sizing = if new_dirty_flags.contains(StyleFlags::BOX_SIZING) {
+            new.box_sizing
+        } else {
+            old.box_sizing
+        };
+
+        let scrollbar_width = if new_dirty_flags.contains(StyleFlags::SCROLLBAR_WIDTH) {
+            new.scrollbar_width
+        } else {
+            old.scrollbar_width
+        };
+
+        let position = if new_dirty_flags.contains(StyleFlags::POSITION) {
+            new.position
+        } else {
+            old.position
+        };
+
+        let margin = if new_dirty_flags.contains(StyleFlags::MARGIN) {
+            new.margin
+        } else {
+            old.margin
+        };
+
+        let padding = if new_dirty_flags.contains(StyleFlags::PADDING) {
+            new.padding
+        } else {
+            old.padding
+        };
+
+        let gap = if new_dirty_flags.contains(StyleFlags::GAP) {
+            new.gap
+        } else {
+            old.gap
+        };
+
+        let inset = if new_dirty_flags.contains(StyleFlags::INSET) {
+            new.inset
+        } else {
+            old.inset
+        };
+
+        let width = if new_dirty_flags.contains(StyleFlags::WIDTH) {
+            new.width
+        } else {
+            old.width
+        };
+
+        let height = if new_dirty_flags.contains(StyleFlags::HEIGHT) {
+            new.height
+        } else {
+            old.height
+        };
+
+        let max_width = if new_dirty_flags.contains(StyleFlags::MAX_WIDTH) {
+            new.max_width
+        } else {
+            old.max_width
+        };
+
+        let max_height = if new_dirty_flags.contains(StyleFlags::MAX_HEIGHT) {
+            new.max_height
+        } else {
+            old.max_height
+        };
+
+        let min_width = if new_dirty_flags.contains(StyleFlags::MIN_WIDTH) {
+            new.min_width
+        } else {
+            old.min_width
+        };
+
+        let min_height = if new_dirty_flags.contains(StyleFlags::MIN_HEIGHT) {
+            new.min_height
+        } else {
+            old.min_height
+        };
+
+        let x = if new_dirty_flags.contains(StyleFlags::X) {
+            new.x
+        } else {
+            old.x
+        };
+
+        let y = if new_dirty_flags.contains(StyleFlags::Y) {
+            new.y
+        } else {
+            old.y
+        };
+
+        let display = if new_dirty_flags.contains(StyleFlags::DISPLAY) {
+            new.display
+        } else {
+            old.display
+        };
+
+        let wrap = if new_dirty_flags.contains(StyleFlags::WRAP) {
+            new.wrap
+        } else {
+            old.wrap
+        };
+
+        let align_items = if new_dirty_flags.contains(StyleFlags::ALIGN_ITEMS) {
+            new.align_items
+        } else {
+            old.align_items
+        };
+
+        let justify_content = if new_dirty_flags.contains(StyleFlags::JUSTIFY_CONTENT) {
+            new.justify_content
+        } else {
+            old.justify_content
+        };
+
+        let flex_direction = if new_dirty_flags.contains(StyleFlags::FLEX_DIRECTION) {
+            new.flex_direction
+        } else {
+            old.flex_direction
+        };
+
+        let flex_grow = if new_dirty_flags.contains(StyleFlags::FLEX_GROW) {
+            new.flex_grow
+        } else {
+            old.flex_grow
+        };
+
+        let flex_shrink = if new_dirty_flags.contains(StyleFlags::FLEX_SHRINK) {
+            new.flex_shrink
+        } else {
+            old.flex_shrink
+        };
+
+        let flex_basis = if new_dirty_flags.contains(StyleFlags::FLEX_BASIS) {
+            new.flex_basis
+        } else {
+            old.flex_basis
+        };
+
+        let color = if new_dirty_flags.contains(StyleFlags::COLOR) {
+            new.color
+        } else {
+            old.color
+        };
+
+        let background = if new_dirty_flags.contains(StyleFlags::BACKGROUND) {
+            new.background
+        } else {
+            old.background
+        };
+
+        let font_size = if new_dirty_flags.contains(StyleFlags::FONT_SIZE) {
+            new.font_size
+        } else {
+            old.font_size
+        };
+
+        let font_weight = if new_dirty_flags.contains(StyleFlags::FONT_WEIGHT) {
+            new.font_weight
+        } else {
+            old.font_weight
+        };
+
+        let font_style = if new_dirty_flags.contains(StyleFlags::FONT_STYLE) {
+            new.font_style
+        } else {
+            old.font_style
+        };
+
+        let overflow = if new_dirty_flags.contains(StyleFlags::OVERFLOW) {
+            new.overflow
+        } else {
+            old.overflow
+        };
+
+        let border_color = if new_dirty_flags.contains(StyleFlags::BORDER_COLOR) {
+            new.border_color
+        } else {
+            old.border_color
+        };
+
+        let border_width = if new_dirty_flags.contains(StyleFlags::BORDER_WIDTH) {
+            new.border_width
+        } else {
+            old.border_width
+        };
+
+        let border_radius = if new_dirty_flags.contains(StyleFlags::BORDER_RADIUS) {
+            new.border_radius
+        } else {
+            old.border_radius
+        };
+
+        let scrollbar_color = if new_dirty_flags.contains(StyleFlags::SCROLLBAR_COLOR) {
+            new.scrollbar_color
+        } else {
+            old.scrollbar_color
+        };
+
+        let dirty_flags = old_dirty_flags | new_dirty_flags;
+
+        Self {
+            font_family_length,
+            font_family,
+            box_sizing,
+            scrollbar_width,
+            position,
+            margin,
+            padding,
+            gap,
+            inset,
+            width,
+            height,
+            max_width,
+            max_height,
+            min_width,
+            min_height,
+            x,
+            y,
+            display,
+            wrap,
+            align_items,
+            justify_content,
+            flex_direction,
+            flex_grow,
+            flex_shrink,
+            flex_basis,
+            color,
+            background,
+            font_size,
+            font_weight,
+            font_style,
+            overflow,
+            border_color,
+            border_width,
+            border_radius,
+            scrollbar_color,
+            dirty_flags,
+        }
     }
 }


### PR DESCRIPTION
Changes:
- Adds a default style trait method to `Element`.
- Adds a merge_style static Style method, so that an old and new style can be merged together.
- Adds a Dropdown element. Emits events on open/close and list item selection.
- The Dropdown list and Dropdown container styles both have default styles but can be overridden by the user if desired.
- Change the default scrollbar width from 15.0 to 10.0.