### PR TITLE
Use Smol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +822,7 @@ dependencies = [
  "pulldown-cmark",
  "rustc-hash 2.1.1",
  "smallvec",
+ "smol_str 0.3.2",
  "syntect",
  "taffy",
  "tinyvg-rs",
@@ -3623,6 +3633,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5413,7 +5433,7 @@ dependencies = [
  "rustix 0.38.44",
  "sctk-adwaita",
  "smithay-client-toolkit",
- "smol_str",
+ "smol_str 0.2.2",
  "tracing",
  "unicode-segmentation",
  "wasm-bindgen",

--- a/crates/craft_core/Cargo.toml
+++ b/crates/craft_core/Cargo.toml
@@ -30,6 +30,8 @@ default = ["clipboard", "accesskit"]
 [dependencies]
 craft_logging = { path = "../craft_logger", version = "0.1.0" }
 
+smol_str = "0.3.2"
+
 [dependencies.cfg-if]
 workspace = true
 

--- a/crates/craft_core/src/animations/animation.rs
+++ b/crates/craft_core/src/animations/animation.rs
@@ -6,6 +6,7 @@ use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::iter::zip;
 use std::time::Duration;
+use smol_str::SmolStr;
 
 #[derive(Clone, Debug)]
 pub struct KeyFrame {
@@ -80,7 +81,7 @@ pub enum TimingFunction {
 
 #[derive(Clone, Debug)]
 pub struct Animation {
-    pub name: String,
+    pub name: SmolStr,
     pub key_frames: SmallVec<[KeyFrame; 2]>,
     pub duration: Duration,
     pub timing_function: TimingFunction,
@@ -96,7 +97,7 @@ pub enum LoopAmount {
 impl Animation {
     pub fn new(name: &str, duration: Duration, timing_function: TimingFunction) -> Self {
         Self {
-            name: name.to_string(),
+            name: name.into(),
             key_frames: SmallVec::new(),
             duration,
             timing_function,

--- a/crates/craft_core/src/components/component.rs
+++ b/crates/craft_core/src/components/component.rs
@@ -9,6 +9,7 @@ use crate::elements::{Container, Element};
 use crate::window_context::WindowContext;
 use std::any::{Any, TypeId};
 use std::ops::Deref;
+use smol_str::SmolStr;
 
 /// A Component's view function.
 pub type ViewFn = fn(
@@ -42,7 +43,7 @@ pub struct ComponentData {
     pub view_fn: ViewFn,
     pub update_fn: UpdateFn,
     /// A unique identifier for view_fn.
-    pub tag: String,
+    pub tag: SmolStr,
     /// The type id of the view function. This is currently not used.
     pub type_id: TypeId,
 }
@@ -59,7 +60,7 @@ pub enum ComponentOrElement {
 pub struct ComponentSpecification {
     pub component: ComponentOrElement,
     /// Specify a key when the component position or type may change, but state should be retained.
-    pub key: Option<String>,
+    pub key: Option<SmolStr>,
     /// A read only reference to the props of the component.
     pub props: Option<Props>,
     /// The children of the component.
@@ -79,8 +80,8 @@ impl ComponentSpecification {
         }
     }
 
-    pub fn key(mut self, key: &str) -> Self {
-        self.key = Some(key.to_owned());
+    pub fn key<T: Into<SmolStr>>(mut self, key: T) -> Self {
+        self.key = Some(key.into());
         self
     }
 
@@ -416,7 +417,7 @@ where
             default_props: Self::default_props,
             view_fn: Self::generic_view_internal,
             update_fn: Self::update_internal,
-            tag: std::any::type_name_of_val(&Self::generic_view_internal).to_string(),
+            tag: std::any::type_name_of_val(&Self::generic_view_internal).into(),
             type_id: Self::generic_view_internal.type_id(),
         };
 

--- a/crates/craft_core/src/devtools/dev_tools_element.rs
+++ b/crates/craft_core/src/devtools/dev_tools_element.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use kurbo::Affine;
 use taffy::{NodeId, TaffyTree};
 use winit::window::Window;
+use smol_str::SmolStr;
 
 #[derive(Clone, Default)]
 pub struct DevTools {

--- a/crates/craft_core/src/devtools/layout_window.rs
+++ b/crates/craft_core/src/devtools/layout_window.rs
@@ -353,7 +353,8 @@ impl Component for LayoutWindow {
     }
 
     fn update(context: &mut Context<Self>) {
-        if let Some(id) = context.target().and_then(|e| e.get_id().clone()) {
+        let id = context.target().and_then(|e| e.get_id().map(|id| id.to_string()));
+        if let Some(id) = id {
             if context.message().clicked() {
                 if id == "tab_styles" {
                     context.state_mut().layout_tab = LayoutTab::Styles

--- a/crates/craft_core/src/devtools/tree_window.rs
+++ b/crates/craft_core/src/devtools/tree_window.rs
@@ -58,7 +58,7 @@ pub(crate) fn tree_window(
             row = row.push(
                 Container::new()
                     .push(
-                        Text::new(custom_id.as_str())
+                        Text::new(custom_id)
                             .color(Color::WHITE)
                             .margin("2.5px", "10px", "2.5px", "10px")
                     )

--- a/crates/craft_core/src/elements/base_element_state.rs
+++ b/crates/craft_core/src/elements/base_element_state.rs
@@ -3,6 +3,7 @@ use crate::elements::element_states::ElementState;
 use crate::style::Style;
 use std::collections::HashMap;
 use rustc_hash::FxHashMap;
+use smol_str::SmolStr;
 use crate::animations::animation::ActiveAnimation;
 
 #[derive(Debug, Default, Clone)]
@@ -15,7 +16,7 @@ pub struct BaseElementState {
     /// Useful for scroll thumbs.
     pub(crate) pointer_capture: HashMap<i64, bool>,
     pub(crate) focused: bool,
-    pub(crate) animations: Option<FxHashMap<String, ActiveAnimation>>,
+    pub(crate) animations: Option<FxHashMap<SmolStr, ActiveAnimation>>,
 }
 
 impl<'a> BaseElementState {

--- a/crates/craft_core/src/elements/canvas.rs
+++ b/crates/craft_core/src/elements/canvas.rs
@@ -18,6 +18,7 @@ use kurbo::Affine;
 use taffy::{NodeId, TaffyTree};
 use winit::window::Window;
 use crate::elements::StatefulElement;
+use smol_str::SmolStr;
 
 #[derive(Clone, Default)]
 pub struct Canvas {

--- a/crates/craft_core/src/elements/container.rs
+++ b/crates/craft_core/src/elements/container.rs
@@ -19,6 +19,7 @@ use kurbo::Affine;
 use taffy::{NodeId, TaffyTree};
 use winit::window::Window;
 use crate::elements::StatefulElement;
+use smol_str::SmolStr;
 
 /// An element for storing related elements.
 #[derive(Clone, Default)]

--- a/crates/craft_core/src/elements/dropdown.rs
+++ b/crates/craft_core/src/elements/dropdown.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use kurbo::Affine;
 use taffy::{NodeId, Position, TaffyTree, TraversePartialTree};
 use winit::window::Window;
+use smol_str::SmolStr;
 
 /// The index of the dropdown list in the layout tree.
 const DROPDOWN_LIST_INDEX: usize = 1;

--- a/crates/craft_core/src/elements/element.rs
+++ b/crates/craft_core/src/elements/element.rs
@@ -74,7 +74,7 @@ pub trait Element: Any + StandardElementClone + Send + Sync {
     }
 
     fn get_id(&self) -> Option<&str> {
-        self.element_data().id.as_ref().map(|id| id.as_str())
+        self.element_data().id.as_deref()
     }
 
     fn component_id(&self) -> ComponentId {

--- a/crates/craft_core/src/elements/element.rs
+++ b/crates/craft_core/src/elements/element.rs
@@ -22,6 +22,7 @@ use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
 use rustc_hash::FxHashMap;
+use smol_str::SmolStr;
 use taffy::{NodeId, Overflow, TaffyTree};
 use winit::window::Window;
 
@@ -72,7 +73,7 @@ pub trait Element: Any + StandardElementClone + Send + Sync {
         }
     }
 
-    fn get_id(&self) -> &Option<String> {
+    fn get_id(&self) -> &Option<SmolStr> {
         &self.element_data().id
     }
 
@@ -552,8 +553,8 @@ macro_rules! generate_component_methods_no_children {
         }
 
         #[allow(dead_code)]
-        pub fn key(mut self, key: &str) -> Self {
-            self.element_data.key = Some(key.to_string());
+        pub fn key<T: Into<SmolStr>>(mut self, key: T) -> Self {
+            self.element_data.key = Some(key.into());
             self
         }
 
@@ -564,8 +565,8 @@ macro_rules! generate_component_methods_no_children {
         }
 
         #[allow(dead_code)]
-        pub fn id(mut self, id: &str) -> Self {
-            self.element_data.id = Some(id.to_string());
+        pub fn id<T: Into<SmolStr>>(mut self, id: T) -> Self {
+            self.element_data.id = Some(id.into());
             self
         }
 
@@ -640,6 +641,7 @@ macro_rules! generate_component_methods_private_push {
 
 #[macro_export]
 macro_rules! generate_component_methods {
+
     () => {
         $crate::generate_component_methods_no_children!();
 

--- a/crates/craft_core/src/elements/element.rs
+++ b/crates/craft_core/src/elements/element.rs
@@ -73,8 +73,8 @@ pub trait Element: Any + StandardElementClone + Send + Sync {
         }
     }
 
-    fn get_id(&self) -> &Option<SmolStr> {
-        &self.element_data().id
+    fn get_id(&self) -> Option<&str> {
+        self.element_data().id.as_ref().map(|id| id.as_str())
     }
 
     fn component_id(&self) -> ComponentId {

--- a/crates/craft_core/src/elements/element_data.rs
+++ b/crates/craft_core/src/elements/element_data.rs
@@ -1,3 +1,4 @@
+use smol_str::SmolStr;
 use crate::components::{ComponentId, ComponentSpecification};
 use crate::components::Props;
 use crate::elements::element::ElementBoxed;
@@ -31,14 +32,14 @@ pub struct ElementData {
     pub children: Vec<ElementBoxed>,
 
     /// A user-defined id for the element.
-    pub id: Option<String>,
+    pub id: Option<SmolStr>,
 
     /// The id of the component that this element belongs to.
     pub component_id: ComponentId,
 
     // Used for converting the element to a component specification.
     pub child_specs: Vec<ComponentSpecification>,
-    pub(crate) key: Option<String>,
+    pub(crate) key: Option<SmolStr>,
     pub(crate) props: Option<Props>,
     pub(crate) event_handlers: EventHandlers,
 }

--- a/crates/craft_core/src/elements/element_pre_order_iterator.rs
+++ b/crates/craft_core/src/elements/element_pre_order_iterator.rs
@@ -82,12 +82,12 @@ mod tests {
         initial_tree.component_tree.print_tree();
 
         let mut iter = initial_tree.element_tree.internal.pre_order_iter();
-        assert_eq!(iter.next().unwrap().get_id().clone(), Some("0".to_string()));
-        assert_eq!(iter.next().unwrap().get_id().clone(), Some("1".to_string()));
-        assert_eq!(iter.next().unwrap().get_id().clone(), Some("2".to_string()));
-        assert_eq!(iter.next().unwrap().get_id().clone(), Some("3".to_string()));
-        assert_eq!(iter.next().unwrap().get_id().clone(), Some("4".to_string()));
-        assert_eq!(iter.next().unwrap().get_id().clone(), Some("5".to_string()));
+        assert_eq!(iter.next().unwrap().get_id().clone(), Some("0".into()));
+        assert_eq!(iter.next().unwrap().get_id().clone(), Some("1".into()));
+        assert_eq!(iter.next().unwrap().get_id().clone(), Some("2".into()));
+        assert_eq!(iter.next().unwrap().get_id().clone(), Some("3".into()));
+        assert_eq!(iter.next().unwrap().get_id().clone(), Some("4".into()));
+        assert_eq!(iter.next().unwrap().get_id().clone(), Some("5".into()));
         assert!(iter.next().is_none());
     }
 }

--- a/crates/craft_core/src/elements/font.rs
+++ b/crates/craft_core/src/elements/font.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use kurbo::Affine;
 use taffy::{NodeId, TaffyTree};
 use winit::window::Window;
+use smol_str::SmolStr;
 
 #[derive(Clone)]
 pub struct Font {

--- a/crates/craft_core/src/elements/image.rs
+++ b/crates/craft_core/src/elements/image.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use kurbo::Affine;
 use taffy::{NodeId, TaffyTree};
 use winit::window::Window;
+use smol_str::SmolStr;
 
 #[derive(Clone)]
 pub struct Image {

--- a/crates/craft_core/src/elements/overlay.rs
+++ b/crates/craft_core/src/elements/overlay.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use kurbo::Affine;
 use taffy::{NodeId, TaffyTree};
 use winit::window::Window;
+use smol_str::SmolStr;
 
 /// An element for storing related elements.
 #[derive(Clone, Default)]

--- a/crates/craft_core/src/elements/slider.rs
+++ b/crates/craft_core/src/elements/slider.rs
@@ -25,6 +25,7 @@ use ui_events::keyboard::{Code, KeyState};
 use ui_events::keyboard::Code::{ArrowDown, ArrowLeft, ArrowRight, ArrowUp};
 use winit::window::Window;
 use crate::elements::StatefulElement;
+use smol_str::SmolStr;
 
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
 pub enum SliderDirection {

--- a/crates/craft_core/src/elements/switch.rs
+++ b/crates/craft_core/src/elements/switch.rs
@@ -20,6 +20,7 @@ use taffy::{NodeId, TaffyTree};
 use ui_events::keyboard::{Code, KeyState};
 use winit::window::Window;
 use crate::elements::StatefulElement;
+use smol_str::SmolStr;
 
 /// An element that represents an on or off state.
 #[derive(Clone)]

--- a/crates/craft_core/src/elements/text.rs
+++ b/crates/craft_core/src/elements/text.rs
@@ -43,7 +43,7 @@ use smol_str::SmolStr;
 // A stateful element that shows text.
 #[derive(Clone, Default)]
 pub struct Text {
-    text: Option<String>,
+    text: Option<SmolStr>,
     element_data: ElementData,
     selectable: bool,
 }
@@ -51,7 +51,7 @@ pub struct Text {
 pub struct TextState {
     scale_factor: f32,
     selection: Selection,
-    text: Option<String>,
+    text: Option<SmolStr>,
     text_hash: Option<u64>,
     text_render: Option<TextRender>,
     last_text_style: Style,
@@ -75,7 +75,7 @@ impl StatefulElement<TextState> for Text {}
 impl Text {
     pub fn new(text: &str) -> Text {
         Text {
-            text: Some(text.to_string()),
+            text: Some(text.into()),
             element_data: Default::default(),
             selectable: true,
         }
@@ -321,7 +321,7 @@ impl Element for Text {
 
         let mut current_node = accesskit::Node::new(Role::Label);
         let padding_box = self.element_data().layout_item.computed_box_transformed.padding_rectangle().scale(scale_factor);
-        current_node.set_value(*Box::new(state.text.clone().unwrap()));
+        current_node.set_value(state.text.as_deref().unwrap());
         current_node.add_action(Action::SetTextSelection);
 
         current_node.set_bounds(accesskit::Rect {

--- a/crates/craft_core/src/elements/text.rs
+++ b/crates/craft_core/src/elements/text.rs
@@ -38,6 +38,7 @@ use winit::dpi;
 use web_time as time;
 use winit::window::Window;
 use craft_primitives::ColorBrush;
+use smol_str::SmolStr;
 
 // A stateful element that shows text.
 #[derive(Clone, Default)]

--- a/crates/craft_core/src/elements/text_input.rs
+++ b/crates/craft_core/src/elements/text_input.rs
@@ -38,6 +38,7 @@ use crate::elements::base_element_state::BaseElementState;
 use crate::reactive::element_id::create_unique_element_id;
 use crate::text::parley_editor::{PlainEditor, PlainEditorDriver};
 use crate::utils::cloneable_any::CloneableAny;
+use smol_str::SmolStr;
 
 // A stateful element that shows text.
 #[derive(Clone, Default)]

--- a/crates/craft_core/src/elements/tinyvg.rs
+++ b/crates/craft_core/src/elements/tinyvg.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use kurbo::Affine;
 use taffy::{NodeId, TaffyTree};
 use winit::window::Window;
+use smol_str::SmolStr;
 
 #[derive(Clone)]
 pub struct TinyVg {

--- a/crates/craft_core/src/reactive/tree.rs
+++ b/crates/craft_core/src/reactive/tree.rs
@@ -13,15 +13,16 @@ use crate::text::text_context::TextContext;
 use crate::window_context::WindowContext;
 use crate::GlobalState;
 use std::collections::{HashMap, HashSet, VecDeque};
+use smol_str::SmolStr;
 
 #[derive(Clone)]
 pub(crate) struct ComponentTreeNode {
     pub is_element: bool,
-    pub key: Option<String>,
-    pub tag: String,
+    pub key: Option<SmolStr>,
+    pub tag: SmolStr,
     pub update: UpdateFn,
     pub children: Vec<ComponentTreeNode>,
-    pub children_keys: HashMap<String, ComponentId>,
+    pub children_keys: HashMap<SmolStr, ComponentId>,
     pub id: ComponentId,
     pub(crate) parent_id: Option<ComponentId>,
     pub props: Props,
@@ -104,7 +105,7 @@ pub(crate) fn diff_trees(
         let mut component_tree = ComponentTreeNode {
             is_element: true,
             key: None,
-            tag: "root".to_string(),
+            tag: "root".into(),
             update: dummy_update,
             children: vec![],
             children_keys: HashMap::new(),
@@ -157,7 +158,7 @@ pub(crate) fn diff_trees(
                     let mut element = element;
 
                     // Store the new tag, i.e. the element's name.
-                    let new_tag = element.internal.name().to_string();
+                    let new_tag = element.internal.name();
 
                     let mut should_update = false;
                     let id = match old_tag {
@@ -202,7 +203,7 @@ pub(crate) fn diff_trees(
                     let new_component_node = ComponentTreeNode {
                         is_element: true,
                         key: new_spec.key,
-                        tag: new_tag,
+                        tag: new_tag.into(),
                         update: dummy_update,
                         children: vec![],
                         children_keys: HashMap::new(),

--- a/examples/overlay/main.rs
+++ b/examples/overlay/main.rs
@@ -76,11 +76,10 @@ impl Component for OverlayExample {
 
     fn update(context: &mut Context<Self>) {
         println!("{:?}", context.window());
-
-        let target = context.target().map(|target| target.get_id()).cloned();
-        if let Some(target) = target {
-            context.state_mut().hovered_element_id = target.clone().map(|s| s.into());
-            if let Some(_id) = target {
+        
+        if let Some(target) = context.target() {
+            context.state_mut().hovered_element_id = target.get_id().map(|s| s.to_string());
+            if let Some(_id) = &context.state_mut().hovered_element_id {
                 context.event_mut().prevent_propagate();
             }
         } else {

--- a/examples/overlay/main.rs
+++ b/examples/overlay/main.rs
@@ -79,7 +79,7 @@ impl Component for OverlayExample {
 
         let target = context.target().map(|target| target.get_id()).cloned();
         if let Some(target) = target {
-            context.state_mut().hovered_element_id = target.clone();
+            context.state_mut().hovered_element_id = target.clone().map(|s| s.into());
             if let Some(_id) = target {
                 context.event_mut().prevent_propagate();
             }

--- a/website/src/examples.rs
+++ b/website/src/examples.rs
@@ -83,7 +83,7 @@ fn examples_sidebar(example_to_show: &String, window: &WindowContext) -> Compone
                 .max_width("300px");
         
         for (index, link) in links.drain(..).enumerate() {
-            if *link.get_id() == Some(example_to_show.to_string().into()) {
+            if link.get_id() == Some(example_to_show) {
                 dropdown = dropdown.set_default(index);
             }
             dropdown = dropdown.push(link);

--- a/website/src/examples.rs
+++ b/website/src/examples.rs
@@ -83,7 +83,7 @@ fn examples_sidebar(example_to_show: &String, window: &WindowContext) -> Compone
                 .max_width("300px");
         
         for (index, link) in links.drain(..).enumerate() {
-            if *link.get_id() == Some(example_to_show.to_string()) {
+            if *link.get_id() == Some(example_to_show.to_string().into()) {
                 dropdown = dropdown.set_default(index);
             }
             dropdown = dropdown.push(link);

--- a/website/src/navbar.rs
+++ b/website/src/navbar.rs
@@ -75,7 +75,7 @@ impl Component for Navbar {
             return;
         }
 
-        let id = context.target().and_then(|e| e.get_id().as_ref()).cloned();
+        let id = context.target().and_then(|e| e.get_id().map(|s| s.to_string()));
         if let Some(current_target) = id {
             if current_target.starts_with("route_") {
                 let route = current_target.trim_start_matches("route_");


### PR DESCRIPTION
## Experiment: Use Smol to reduce heap allocations

Two different scenarios were measured for the tour example:
1. The memory usage on the first render
2. The memory usage n frames later (this should be about the same across frames)

Three different scenarios were measured for the 10k rows example:
1. The memory usage on the first render
2. The memory usage n frames later (this should be about the same across frames)
3. The memory usage after generating 10k rows

## Usability (as a user):
SmolString is invisible to the user in the `view` due to impl Into being used and the experience is better than before. In update however the usage is slightly worse when getting a target's id and storing it because you have to call .into().

## Results (Summary):
### Tour Measurements

| TOUR EXAMPLE              | STARTING FRAME                              | N FRAMES LATER                             |
| ------------------------- | ------------------------------------------- | ------------------------------------------ |
| Without Smol              | allocations: 2991, bytes allocated: 1182586 | allocations: 1903, bytes allocated: 818369 |
| With Smol                 | allocations: 2935, bytes allocated: 1181426 | allocations: 1848, bytes allocated: 817833 |
| Memory Saved Diff (bytes) | 1160 bytes and 167.04 KB across 144 frames  | 536 bytes and 77.184 KB across 144 frames  |

### 10k Rows Measurements
| 10k Rows Example          | STARTING FRAME                             | N FRAMES LATER                             | 10K ROWS CLICKED AND SHOWING                     |
| ------------------------- | ------------------------------------------ | ------------------------------------------ | ------------------------------------------------ |
| Without Smol              | allocations: 2051, bytes allocated: 570760 | allocations: 1338, bytes allocated: 392832 | allocations: 751489, bytes allocated: 345547457  |
| With Smol                 | allocations: 2022, bytes allocated: 570357 | allocations: 1309, bytes allocated: 392429 | allocations: 661651, bytes allocated: 344849956  |
| Memory Saved Diff (bytes) | 403 bytes and 58.032 KB across 144 frames  | 403 bytes and 58.032 KB across 144 frames  | 697501 bytes and 100.440144 MB across 144 frames |

## How to Measure:
[https://github.com/neoeinstein/stats_alloc](https://github.com/neoeinstein/stats_alloc)

Clone down craft with the smol changes in one directory and then clone it down without the changes in another directory and then for each directory: save the following to a `patch` file and `git apply` the patch file at the root:

```diff
diff --git a/Cargo.lock b/Cargo.lock
index 8c544e3..505ebe6 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "smallvec",
  "smol_str 0.3.2",
+ "stats_alloc",
  "syntect",
  "taffy",
  "tinyvg-rs",
@@ -3705,6 +3706,12 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
+[[package]]
+name = "stats_alloc"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
+
 [[package]]
 name = "strict-num"
 version = "0.1.1"
diff --git a/crates/craft_core/Cargo.toml b/crates/craft_core/Cargo.toml
index 06a39d2..f193422 100644
--- a/crates/craft_core/Cargo.toml
+++ b/crates/craft_core/Cargo.toml
@@ -30,6 +30,7 @@ default = ["clipboard", "accesskit"]
 [dependencies]
 craft_logging = { path = "../craft_logger", version = "0.1.0" }
 
+stats_alloc = "0.1.10"
 smol_str = "0.3.2"
 
 [dependencies.cfg-if]
diff --git a/crates/craft_core/src/app.rs b/crates/craft_core/src/app.rs
index 85d5491..4329c4d 100644
--- a/crates/craft_core/src/app.rs
+++ b/crates/craft_core/src/app.rs
@@ -59,6 +59,15 @@ use craft_resource_manager::resource_type::ResourceType;
 use crate::animations::animation::{AnimationFlags};
 use crate::events::update_queue_entry::UpdateQueueEntry;
 
+extern crate stats_alloc;
+
+use stats_alloc::{StatsAlloc, Region, INSTRUMENTED_SYSTEM};
+use std::alloc::System;
+use std::process;
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
 macro_rules! get_tree {
         ($self:expr, $is_dev_tree:expr) => {{
             if !$is_dev_tree {
@@ -308,6 +317,8 @@ impl App {
     }
 
     fn on_request_redraw_internal(&mut self) {
+        let reg = Region::new(&GLOBAL);
+
         if self.window.is_none() {
             return;
         }
@@ -414,6 +425,8 @@ impl App {
         }
 
         self.view_introspection();
+        println!("Per-frame Allocations: {:#?}", reg.change());
+        // process::exit(0);
     }
 
     pub fn on_pointer_scroll(&mut self, pointer_scroll_update: PointerScrollUpdate) {

```

## Results:
#### **10k rows (WITHOUT Smol):**

**STARTING FRAME:**

Per-frame Allocations: Stats {

    allocations: 2051,

    deallocations: 1207,

    reallocations: 493,

    bytes\_allocated: 570760,

    bytes\_deallocated: 339710,

    bytes\_reallocated: 121657,

}





**N FRAMES LATER:**

Per-frame Allocations: Stats {

    allocations: 1338,

    deallocations: 1336,

    reallocations: 206,

    bytes\_allocated: 392832,

    bytes\_deallocated: 392272,

    bytes\_reallocated: 71448,

}





**10K ROWS CLICKED AND SHOWING:**

Per-frame Allocations: Stats {

    allocations: 751489,

    deallocations: 751487,

    reallocations: 60762,

    bytes\_allocated: 345547457,

    bytes\_deallocated: 345546897,

    bytes\_reallocated: 119599883,

}



---





#### **10k rows (WITH Smol):**



**STARTING FRAME:**

Per-frame Allocations: Stats {

&nbsp;   allocations: 2022,

&nbsp;   deallocations: 1206,

&nbsp;   reallocations: 493,

&nbsp;   bytes\_allocated: 570357,

&nbsp;   bytes\_deallocated: 339618,

&nbsp;   bytes\_reallocated: 121657,

}





**N FRAMES LATER:**

Per-frame Allocations: Stats {

&nbsp;   allocations: 1309,

&nbsp;   deallocations: 1307,

&nbsp;   reallocations: 206,

&nbsp;   bytes\_allocated: 392429,

&nbsp;   bytes\_deallocated: 391869,

&nbsp;   bytes\_reallocated: 71448,

}





**10K ROWS CLICKED AND SHOWING:**

Per-frame Allocations: Stats {

&nbsp;   allocations: 661651,

&nbsp;   deallocations: 661649,

&nbsp;   reallocations: 60762,

&nbsp;   bytes\_allocated: 344849956,

&nbsp;   bytes\_deallocated: 344849396,

&nbsp;   bytes\_reallocated: 119599663,

}






---


#### **Tour (WITHOUT Smol):**



**STARTING FRAME:**

Per-frame Allocations: Stats {

&nbsp;   allocations: 2991,

&nbsp;   deallocations: 1715,

&nbsp;   reallocations: 963,

&nbsp;   bytes\_allocated: 1182586,

&nbsp;   bytes\_deallocated: 707643,

&nbsp;   bytes\_reallocated: 407916,

}





**N FRAMES LATER:**

Per-frame Allocations: Stats {

&nbsp;   allocations: 1903,

&nbsp;   deallocations: 1901,

&nbsp;   reallocations: 484,

&nbsp;   bytes\_allocated: 818369,

&nbsp;   bytes\_deallocated: 817809,

&nbsp;   bytes\_reallocated: 325752,

}



---





#### **Tour (WITH Smol):**



**STARTING FRAME:**

Per-frame Allocations: Stats {

&nbsp;   allocations: 2935,

&nbsp;   deallocations: 1714,

&nbsp;   reallocations: 963,

&nbsp;   bytes\_allocated: 1181426,

&nbsp;   bytes\_deallocated: 707560,

&nbsp;   bytes\_reallocated: 407916,

}





**N FRAMES LATER:**

Per-frame Allocations: Stats {

&nbsp;   allocations: 1848,

&nbsp;   deallocations: 1846,

&nbsp;   reallocations: 484,

&nbsp;   bytes\_allocated: 817833,

&nbsp;   bytes\_deallocated: 817273,

&nbsp;   bytes\_reallocated: 325752,

}



